### PR TITLE
Add .clang-format configuration for auto-formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,69 @@
+# basics
+UseTab: Never
+IndentWidth: 4
+ColumnLimit: 0
+SortIncludes: Never
+
+PointerAlignment: Left
+ReferenceAlignment: Left
+
+AlignAfterOpenBracket: DontAlign # Argument aligned by level not function name ISSUE: ");" is not on a new line
+
+# spaces
+SpaceBeforeParens: Custom
+SpaceBeforeParensOptions:
+  AfterControlStatements: true   # ISSUE: only global for if/while/for/switch but don't want only for if 
+  AfterFunctionDefinitionName: false
+
+#spaces
+MaxEmptyLinesToKeep: 2
+KeepEmptyLinesAtEOF: false
+EmptyLineAfterAccessModifier: Always
+
+BreakBeforeBinaryOperators: None
+
+AlignConsecutiveDeclarations:
+  Enabled: true
+  AcrossEmptyLines: true
+  AcrossComments: false 
+AlignConsecutiveAssignments: 
+  Enabled: true
+  AcrossEmptyLines: true
+  AcrossComments: true
+  AlignCompound: true
+  PadOperators: true
+
+BinPackArguments: false
+BinPackParameters: false
+
+# wrapping/combining
+AllowShortFunctionsOnASingleLine: None
+BreakBeforeBraces: Custom
+BraceWrapping:
+  IndentBraces:    False
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       True
+  AfterFunction:   true
+  AfterNamespace:  True
+  AfterObjCDeclaration: True
+  AfterStruct:     True
+  AfterUnion:      True
+  BeforeCatch:     True
+  BeforeElse:      True
+  BeforeWhile:     True
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+
+# C++ Constructor settings
+BreakConstructorInitializers: AfterColon
+PackConstructorInitializers: Never
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+
+# classes & templates
+IndentAccessModifiers: false
+AccessModifierOffset: -4
+SpacesInAngles: Leave  # Don't change
+
+Cpp11BracedListStyle: false


### PR DESCRIPTION
Add a .clang-format file this is as close to the existing coding style in Pixelix as possible. A few deviations remain as there is not option to enforce the original style.

* AfterControlStatements: true ISSUE: space only global for if/while/for/switch but want only for if.
* Array Initiializer: Cannot get opening "{" on next line.
* initialzer alignment not on  tab boundaries but follows largest variable name.