### PR TITLE
DateTimePlugin: Adding analog clock view configuration

### DIFF
--- a/lib/DateTimePlugin/src/DateTimePlugin.cpp
+++ b/lib/DateTimePlugin/src/DateTimePlugin.cpp
@@ -59,13 +59,23 @@
  *****************************************************************************/
 
 /* Initialize plugin topic. */
-const char* DateTimePlugin::TOPIC_CONFIG        = "/dateTime";
+const char DateTimePlugin::TOPIC_CONFIG[]        = "/dateTime";
 
 /* Initialize default time format. */
-const char* DateTimePlugin::TIME_FORMAT_DEFAULT = "%I:%M %p";
+const char DateTimePlugin::TIME_FORMAT_DEFAULT[] = "%I:%M %p";
 
 /* Initialize default date format. */
-const char* DateTimePlugin::DATE_FORMAT_DEFAULT = "%m/%d";
+const char DateTimePlugin::DATE_FORMAT_DEFAULT[] = "%m/%d";
+
+/* Color key names for the analog clock configuration. */
+const char* DateTimePlugin::ANALOG_CLOCK_COLOR_KEYS[IDateTimeView::ANA_CLK_COL_MAX] =
+{
+    "handHourCol",
+    "handMinCol",
+    "handSecCol",
+    "ringFiveMinCol",
+    "ringMinDotCol"
+};
 
 /******************************************************************************
  * Public Methods
@@ -95,18 +105,22 @@ bool DateTimePlugin::setTopic(const String& topic, const JsonObjectConst& value)
 
     if (true == topic.equals(TOPIC_CONFIG))
     {
-        const size_t        JSON_DOC_SIZE           = 512U;
+        const IDateTimeView::AnalogClockConfig* analogClockCfg = nullptr;
+
+        const size_t        JSON_DOC_SIZE           = 768U;
         DynamicJsonDocument jsonDoc(JSON_DOC_SIZE);
         JsonObject          jsonCfg                 = jsonDoc.to<JsonObject>();
         JsonVariantConst    jsonMode                = value["mode"];
+        JsonVariantConst    jsonViewMode            = value["viewMode"];
         JsonVariantConst    jsonTimeFormat          = value["timeFormat"];
         JsonVariantConst    jsonDateFormat          = value["dateFormat"];
         JsonVariantConst    jsonTimeZone            = value["timeZone"];
         JsonVariantConst    jsonStartOfWeek         = value["startOfWeek"];
         JsonVariantConst    jsonDayOnColor          = value["dayOnColor"];
         JsonVariantConst    jsonDayOffColor         = value["dayOffColor"];
-
-        /* The received configuration may not contain all single key/value pair.
+        JsonObjectConst     jsonAnalogClock         = value["analogClock"];
+       
+         /* The received configuration may not contain all single key/value pair.
          * Therefore read first the complete internal configuration and
          * overwrite them with the received ones.
          */
@@ -122,7 +136,13 @@ bool DateTimePlugin::setTopic(const String& topic, const JsonObjectConst& value)
             jsonCfg["mode"] = jsonMode.as<uint8_t>();
             isSuccessful = true;
         }
-        
+
+        if (false == jsonViewMode.isNull())
+        {
+            jsonCfg["viewMode"] = jsonViewMode.as<uint8_t>();
+            isSuccessful = true;
+        }
+
         if (false == jsonTimeFormat.isNull())
         {
             jsonCfg["timeFormat"] = jsonTimeFormat.as<String>();
@@ -156,6 +176,12 @@ bool DateTimePlugin::setTopic(const String& topic, const JsonObjectConst& value)
         if (false == jsonDayOffColor.isNull())
         {
             jsonCfg["dayOffColor"] = jsonDayOffColor.as<String>();
+            isSuccessful = true;
+        }
+        
+        if (false == jsonAnalogClock.isNull())
+        {
+            jsonCfg["analogClock"] = jsonAnalogClock;
             isSuccessful = true;
         }
 
@@ -262,32 +288,57 @@ void DateTimePlugin::update(YAGfx& gfx)
 
 void DateTimePlugin::getConfiguration(JsonObject& jsonCfg) const
 {
+    const IDateTimeView::AnalogClockConfig* analogClockCfg = nullptr;
+
     MutexGuard<MutexRecursive> guard(m_mutex);
 
     jsonCfg["mode"]         = m_mode;
+    jsonCfg["viewMode"]     = m_view.getViewMode();
     jsonCfg["timeFormat"]   = m_timeFormat;
     jsonCfg["dateFormat"]   = m_dateFormat;
     jsonCfg["timeZone"]     = m_timeZone;
     jsonCfg["startOfWeek"]  = m_view.getStartOfWeek();
     jsonCfg["dayOnColor"]   = colorToHtml(m_view.getDayOnColor());
     jsonCfg["dayOffColor"]  = colorToHtml(m_view.getDayOffColor());
+
+    if (nullptr != (analogClockCfg = m_view.getAnalogClockConfig()))
+    {
+        /* View supports analog clock, add the additinal config elements for it.
+         */
+        JsonObject jsonAnalogClock = jsonCfg.createNestedObject("analogClock");
+        jsonAnalogClock["secondsMode"] = analogClockCfg->m_secondsMode;
+        for (uint32_t index = 0U;  index < IDateTimeView::ANA_CLK_COL_MAX; ++index)
+        {
+            jsonAnalogClock[ANALOG_CLOCK_COLOR_KEYS[index]]= colorToHtml(analogClockCfg->m_colors[index]);
+        }
+    }
+
 }
 
 bool DateTimePlugin::setConfiguration(const JsonObjectConst& jsonCfg)
 {
     bool             status             = false;
     JsonVariantConst jsonMode           = jsonCfg["mode"];
+    JsonVariantConst jsonViewMode       = jsonCfg["viewMode"];
     JsonVariantConst jsonTimeFormat     = jsonCfg["timeFormat"];
     JsonVariantConst jsonDateFormat     = jsonCfg["dateFormat"];
     JsonVariantConst jsonTimeZone       = jsonCfg["timeZone"];
     JsonVariantConst jsonStartOfWeek    = jsonCfg["startOfWeek"];
     JsonVariantConst jsonDayOnColor     = jsonCfg["dayOnColor"];
     JsonVariantConst jsonDayOffColor    = jsonCfg["dayOffColor"];
+    JsonVariantConst jsonAnalogClock    = jsonCfg["analogClock"];
+
+    IDateTimeView::AnalogClockConfig analogClockConfig;
 
     if ((false == jsonMode.is<uint8_t>()) &&
         (MODE_MAX <= jsonMode.as<uint8_t>()))
     {
         LOG_WARNING("JSON mode not found or invalid type.");
+    }
+    else if ((false == jsonViewMode.is<uint8_t>()) &&
+        (IDateTimeView::VIEW_MODE_MAX <= jsonViewMode.as<uint8_t>()))
+    {
+        LOG_WARNING("JSON view mode not found or invalid type.");
     }
     else if (false == jsonTimeFormat.is<String>())
     {
@@ -313,6 +364,9 @@ bool DateTimePlugin::setConfiguration(const JsonObjectConst& jsonCfg)
     {
         LOG_WARNING("JSON day off color not found or invalid type.");
     }
+    else if (false == checkAnalogClockConfig(jsonAnalogClock, analogClockConfig))
+        /* Error printed in checkAnalogClockConfig() already. */
+        ;
     else
     {
         MutexGuard<MutexRecursive> guard(m_mutex);
@@ -325,6 +379,12 @@ bool DateTimePlugin::setConfiguration(const JsonObjectConst& jsonCfg)
         status = m_view.setStartOfWeek(jsonStartOfWeek.as<uint8_t>());
         m_view.setDayOnColor(colorFromHtml(jsonDayOnColor.as<String>()));
         m_view.setDayOffColor(colorFromHtml(jsonDayOffColor.as<String>()));
+        m_view.setViewMode(static_cast<IDateTimeView::ViewMode>(jsonViewMode.as<uint8_t>()));
+
+        if (false == jsonAnalogClock.isNull())
+        {
+            m_view.setAnalogClockConfig(analogClockConfig);
+        }
 
         m_hasTopicChanged = true;
     }
@@ -511,7 +571,7 @@ bool DateTimePlugin::getTimeAsString(String& time, const String& format, const t
     return isSuccessful;
 }
 
-String DateTimePlugin::colorToHtml(const Color& color) const
+String DateTimePlugin::colorToHtml(const Color& color)
 {
     char buffer[8]; /* '#' + 3x byte in hex + '\0' */
 
@@ -520,7 +580,7 @@ String DateTimePlugin::colorToHtml(const Color& color) const
     return String(buffer);
 }
 
-Color DateTimePlugin::colorFromHtml(const String& htmlColor) const
+Color DateTimePlugin::colorFromHtml(const String& htmlColor)
 {
     Color color;
 
@@ -530,6 +590,46 @@ Color DateTimePlugin::colorFromHtml(const String& htmlColor) const
     }
 
     return color;
+}
+
+bool DateTimePlugin::checkAnalogClockConfig(JsonVariantConst& jsonCfg, IDateTimeView::AnalogClockConfig & cfg)
+{
+    bool result = true;
+
+    if (false == jsonCfg.isNull())
+    {
+        JsonVariantConst jsonSecondsMode = jsonCfg["secondsMode"];
+
+        if ((false == jsonSecondsMode.is<uint8_t>()) &&
+            (IDateTimeView::SECONDS_DISP_MAX <= jsonSecondsMode.as<uint8_t>()))
+        {
+            LOG_WARNING("JSON seconds mode not found or invalid type.");
+            result = false;
+        } 
+        else
+        {
+            cfg.m_secondsMode = static_cast<IDateTimeView::SecondsDisplayMode>(jsonSecondsMode.as<uint8_t>());
+
+            for (uint32_t idx = 0U; idx < IDateTimeView::ANA_CLK_COL_MAX; ++ idx)
+            {
+                JsonVariantConst color = jsonCfg[ANALOG_CLOCK_COLOR_KEYS[idx]];
+
+                if (false == color.is<String>())
+                {
+                    LOG_WARNING(
+                        "JSON attribute %s not found or invalid type.",
+                        ANALOG_CLOCK_COLOR_KEYS[idx]);
+                    result = false;
+                }
+                else
+                {
+                    cfg.m_colors[idx] = colorFromHtml(color);
+                }
+            }
+        }
+    }
+
+    return result;
 }
 
 /******************************************************************************

--- a/lib/DateTimePlugin/src/DateTimePlugin.h
+++ b/lib/DateTimePlugin/src/DateTimePlugin.h
@@ -279,7 +279,7 @@ private:
     /**
      * Plugin topic, used to read/write the configuration.
      */
-    static const char*      TOPIC_CONFIG;
+    static const char      TOPIC_CONFIG[];
 
     /** Time to check date update period in ms */
     static const uint32_t   CHECK_UPDATE_PERIOD     = SIMPLE_TIMER_SECONDS(1U);
@@ -288,10 +288,13 @@ private:
     static const uint32_t   MS_TO_SEC_DIVIDER       = 1000U;
 
     /** Default time format according to strftime(). */
-    static const char*      TIME_FORMAT_DEFAULT;
+    static const char       TIME_FORMAT_DEFAULT[];
 
     /** Default date format according to strftime(). */
-    static const char*      DATE_FORMAT_DEFAULT;
+    static const char       DATE_FORMAT_DEFAULT[];
+
+    /** Color key names for the analog clock configuration. */
+    static const char*      ANALOG_CLOCK_COLOR_KEYS[IDateTimeView::ANA_CLK_COL_MAX];
 
     /**
      * If the slot duration is infinite (0s), the default duration of 30s shall be assumed as base
@@ -359,7 +362,7 @@ private:
      * 
      * @return Color in HTML format
      */
-    String colorToHtml(const Color& color) const;
+    static String colorToHtml(const Color& color);
 
     /**
      * Convert color from HTML format.
@@ -368,7 +371,18 @@ private:
      * 
      * @return Color
      */
-    Color colorFromHtml(const String& htmlColor) const;
+    static Color colorFromHtml(const String& htmlColor);
+ 
+    /**
+     * Check if analog cfg is valid when present.
+     * 
+     * @param jsonCfg[in]  The json configuration, may be isNull(). 
+     * @param cfg[out]     The parsed config data if json present and valid.
+     * @return true        If no configuration or valid json values.
+     */
+    static bool checkAnalogClockConfig(
+        JsonVariantConst& jsonCfg,
+        IDateTimeView::AnalogClockConfig & cfg);
 };
 
 /******************************************************************************

--- a/lib/DateTimePlugin/web/DateTimePlugin.html
+++ b/lib/DateTimePlugin/web/DateTimePlugin.html
@@ -72,7 +72,7 @@
                 </ul>
                 <h2>Configuration</h2>
                 <h3>Display</h3>
-                <div class="h-100 p-5 bg-body-tertiary border rounded-3">
+                <div class="h-100 p-1 p-md-5 bg-body-tertiary border rounded-3">
                     <form id="myForm" action="javascript:setConfig(pluginUid.options[pluginUid.selectedIndex].value)">
                         <div class="form-group">
                             <label class="form-label" for="pluginUid">Plugin UID:</label>
@@ -118,8 +118,84 @@
                         <div class="form-group">
                             <label class="form-label" for="timeFormat">Color of other days:</label>
                             <input class="form-control" type="text" id="dayOffColor" name="dayOffColor" value="" />    
-                        </div>                    
-                        <input name="submit" type="submit" value="Update"/>
+                        </div>
+                            <div class="container-fluid mt-3 p-0" id="options64x64" style="Display:none">
+                                <label class="form-label">Additional Options for 64x64 Layouts:</label>
+                                <div class="row mt-2 align-content-center">
+                                    <div class="col-12 col-sm-3 pb-2 pb-sm-0">
+                                        <label class="align-middle" for="viewMode">Clock View Mode:</label>
+                                    </div>
+                                    <div class="col-12 col-sm-9">
+                                        <div class="btn-group" role="group">
+                                            <input type="radio" class="btn-check" id="viewMode0" name="viewMode" value="0" checked>
+                                            <label class="btn btn-outline-secondary" for="viewMode0">Digital</label>
+    
+    
+                                            <input type="radio" class="btn-check" id="viewMode1" name="viewMode" value="1" checked>
+                                            <label class="btn btn-outline-secondary" for="viewMode1">Analog</label>
+    
+                                            <input type="radio" class="btn-check" id="viewMode2" name="viewMode" value="2" checked>
+                                            <label class="btn btn-outline-secondary" for="viewMode2">Both</label>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="row mt-2">
+                                    <div class="col-12 col-sm-3 pb-2 pb-sm-0">
+                                        <label class="align-middle" for="secondsMode">Analog Seconds Visualisation:</label>
+                                    </div>
+                                    <div class="col-12 col-sm-9">
+                                        <div class="btn-group" role="group">
+                                            <input type="radio" class="btn-check" id="secondsMode0" name="secondsMode" value="0" checked>
+                                            <label class="btn btn-outline-secondary" for="secondsMode0">Off</label>
+    
+    
+                                            <input type="radio" class="btn-check" id="secondsMode1" name="secondsMode" value="1" checked>
+                                            <label class="btn btn-outline-secondary" for="secondsMode1">Clock Hand</label>
+    
+                                            <input type="radio" class="btn-check" id="secondsMode2" name="secondsMode" value="2" checked>
+                                            <label class="btn btn-outline-secondary" for="secondsMode2">Dial Dots</label>
+                                            
+                                            <input type="radio" class="btn-check" id="secondsMode3" name="secondsMode" value="3" checked>
+                                            <label class="btn btn-outline-secondary" for="secondsMode3">Dial and Hand</label>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="row mt-2">
+                                    <div class="col-12 col-sm-3 pb-2 pb-sm-0">
+                                        <label class="align-middle">Hand Colors (H/M/S):</label>
+                                    </div>
+                                    <div class="col-12 col-sm-9">
+                                        <div class="btn-group" role="group">
+                                            <div class="form-group">
+                                                <input type="color" class="form-control form-control-color" id="handHourCol" value="#FFFFFF" title="Hour Hand Color">
+                                            </div>
+                                            <div class="form-group">
+                                                <input type="color" class="form-control form-control-color" id="handMinCol" value="#808080" title="Minute Hand Color">
+                                            </div>
+                                            <div class="form-group">
+                                                <input type="color" class="form-control form-control-color" id="handSecCol" value="#FFFF00" title="Second Hand Color">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="row mt-2">
+                                    <div class="col-12 col-sm-3 pb-2 pb-sm-0">
+                                        <label class="align-middle">Ring Colors (5min/Dots):</label>
+                                    </div>
+                                    <div class="col-12 col-sm-9">
+                                        <div class="btn-group" role="group">
+                                            <div class="form-group">
+                                                <input type="color" class="form-control form-control-color" id="ringFiveMinCol" value="#0000FF" title="Five Minute Mark Color">
+                                            </div>
+                                            <div class="form-group">
+                                                <input type="color" class="form-control form-control-color" id="ringMinDotCol" value="#A9A9A9" title="Minute Ring Dot Colorr">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <input class="btn btn-secondary mt-3" name="submit" type="submit" value="Update"/>
                     </form>
                 </div>
             </div>
@@ -197,6 +273,7 @@
 
             function getConfig(pluginUid) {
                 disableUI();
+                
                 return utils.makeRequest({
                     method: "GET",
                     url: "/rest/api/v1/display/uid/" + pluginUid + "/dateTime",
@@ -209,6 +286,17 @@
                     $("#startOfWeek").val(rsp.data.startOfWeek);
                     $("#dayOnColor").val(rsp.data.dayOnColor);
                     $("#dayOffColor").val(rsp.data.dayOffColor);
+                    $("#viewMode").val(rsp.data.viewMode);
+
+                    if (rsp.data.hasOwnProperty("analogClock")) {
+                        jsonAnalogClock = rsp.data.analogClock;
+                        $("#handHourCol").val(jsonAnalogClock.handHourCol);
+                        $("#handMinCol").val(jsonAnalogClock.handMinCol);
+                        $("#handSecCol").val(jsonAnalogClock.handSecCol);
+                        $("#ringFiveMinCol").val(jsonAnalogClock.ringFiveMinCol);
+                        $("#ringMinDotCol").val(jsonAnalogClock.ringMinDotCol);
+                    }
+
                 }).catch(function(rsp) {
                     alert("Internal error.");
                 }).finally(function() {
@@ -218,19 +306,41 @@
 
             function setConfig(pluginUid) {
                 disableUI();
-                return utils.makeRequest({
-                    method: "POST",
-                    url: "/rest/api/v1/display/uid/" + pluginUid + "/dateTime",
-                    isJsonResponse: true,
-                    parameter: {
+
+                let displayWidth = ~DISPLAY_HEIGHT~;
+                let displayHeight = ~DISPLAY_HEIGHT~;
+
+                configJson = {
                         mode: $("#mode").val(),
                         timeFormat: $("#timeFormat").val(),
                         dateFormat: $("#dateFormat").val(),
                         timeZone: $("#timeZone").val(),
                         startOfWeek: $("#startOfWeek").val(),
                         dayOnColor: $("#dayOnColor").val(),
-                        dayOffColor: $("#dayOffColor").val()
-                    }
+                        dayOffColor: $("#dayOffColor").val(),
+                        handHourCol: $("#handHourCol").val(),
+                        viewMode: $('input[name=viewMode]:checked').val()
+
+                    };
+
+                if ((64 <= ~DISPLAY_HEIGHT~) && (64 <= ~DISPLAY_WIDTH~))
+                {
+                    configJson["analogClock"] = 
+                        {
+                            secondsMode: $('input[name=secondsMode]:checked').val(),
+                            handHourCol: $("#handHourCol").val(),
+                            handMinCol: $("#handMinCol").val(),
+                            handSecCol: $("#handSecCol").val(),
+                            ringFiveMinCol: $("#ringFiveMinCol").val(),
+                            ringMinDotCol: $("#ringMinDotCol").val()
+                        };
+                }
+
+                return utils.makeRequest({
+                    method: "POST",
+                    url: "/rest/api/v1/display/uid/" + pluginUid + "/dateTime",
+                    isJsonResponse: true,
+                    parameter: configJson
                 }).then(function(rsp) {
                     alert("Ok.");
                 }).catch(function(rsp) {
@@ -248,6 +358,15 @@
 
                 /* Disable all forms, until the plugin instances are loaded. */
                 disableUI();
+
+                let displayWidth = ~DISPLAY_WIDTH~;
+                let displayHeight = ~DISPLAY_HEIGHT~;
+
+                /* Enable extended options for screens >= 64x64. */
+                if ((displayWidth >= 64) && (displayHeight >= 64)) {
+                    let opt64x64 = document.getElementById("options64x64");
+                    opt64x64.style.display  = "block";
+                }
 
                 /* Load all plugin instances. */
                 getPluginInstances().then(function(cnt) {

--- a/lib/Views/src/IDateTimeView.h
+++ b/lib/Views/src/IDateTimeView.h
@@ -70,6 +70,50 @@ public:
     }
 
     /**
+     * The view modes, which influences how the data is
+     * shown on the display.
+     */
+    enum ViewMode
+    {
+        DIGITAL_ONLY = 0U,       /**< Show date and time */
+        ANALOG_ONLY,             /**< Show only the date */
+        DIGITAL_AND_ANALOG,      /**< Show only the time */
+        VIEW_MODE_MAX            /**< Number of configurations */
+    };
+
+    /** 
+     * Options for displaying seconds in analog clock.
+     */
+    enum SecondsDisplayMode
+    {
+        SECOND_DISP_OFF = 0U,  /**< No second indicator display. */
+        SECOND_DISP_HAND = 1U, /**< Draw second clock hand. */
+        SECOND_DISP_RING = 2U, /**< Show passed seconds on minute tick ring. */
+        SECOND_DISP_BOTH = 3U, /**< Show hand and on ring. */
+        SECONDS_DISP_MAX       /**< Number of configurations. */
+    };
+
+    /** 
+     * Color array indexes for the analog clock drawing.
+     */
+    enum AnalogClockColor
+    {
+        ANA_CLK_COL_HAND_HOUR = 0U, /**< Hour clock hand color. */
+        ANA_CLK_COL_HAND_MIN,       /**< Minutes clock hand color. */
+        ANA_CLK_COL_HAND_SEC,       /**< Seconds colock hand color */
+        ANA_CLK_COL_RING_MIN5_MARK, /**< Ring five minute marks color. */
+        ANA_CLK_COL_RING_MIN_DOT,   /**< Ring minut dots color. */
+        ANA_CLK_COL_MAX             /**< Number of colors. */
+    };
+
+    /** Analog clock appearance configuration. */
+    struct AnalogClockConfig
+    {
+        SecondsDisplayMode m_secondsMode;              /**< Seconds visualisation mode. */
+        Color              m_colors[ANA_CLK_COL_MAX];  /**< Clock colors to use.        */
+    };
+
+    /**
      * Initialize view, which will prepare the widgets and the default values.
      */
     virtual void init(uint16_t width, uint16_t height) = 0;
@@ -161,9 +205,39 @@ public:
     virtual void setDayOffColor(const Color& color) = 0;
 
     /**
+     * Get the view mode (analog, digital or both).
+     * 
+     * @return ViewMode 
+     */
+    virtual ViewMode getViewMode() const = 0;
+
+    /**
+     * Set the view mode (analog, digital or both).
+     * 
+     * @return bool success of failure 
+     */
+    virtual bool setViewMode(ViewMode mode) = 0;
+
+    /**
+     * Get the analog clock clonfiguration.
+     * 
+     * @return AnalogClockConfig or nullptr if unsupported.
+     */
+    virtual const AnalogClockConfig* getAnalogClockConfig() const = 0;
+
+    /**
+     * Set the analog clock configuration.
+     * 
+     * @param[in] cfg The new configuration to apply.
+     * 
+     * @return success or failure
+     */
+    virtual bool setAnalogClockConfig(const AnalogClockConfig& cfg) = 0;
+
+    /**
      * @brief Update current time values in view.
      * 
-     * @param now current time
+     * @param[in] now current time
      */
     virtual void setCurrentTime(const tm& now) = 0;
 

--- a/lib/Views/src/layouts/DateTimeView32x8.h
+++ b/lib/Views/src/layouts/DateTimeView32x8.h
@@ -250,6 +250,51 @@ public:
     }
 
     /**
+     * Get the view mode (analog, digital or both).
+     * 
+     * @return ViewMode 
+     */
+    ViewMode getViewMode() const override
+    {
+        return ViewMode::DIGITAL_ONLY;  /* 32X8 layout can only do digital.*/
+    }
+
+    /**
+     * Set the view mode (analog, digital or both).
+     * 
+     * @return ViewMode 
+     */
+    bool setViewMode(ViewMode mode) override
+    {
+        if (ViewMode::DIGITAL_ONLY != mode)
+        {
+            LOG_WARNING("Illegal DateTime view mode for 32X8: (%hhu)", mode);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Get the analog clock seconds display mode (none, ring, hand or both).
+     * 
+     * @return SecondsDisplayMode pointer or nullptr if unsupported. 
+     */
+    virtual const AnalogClockConfig* getAnalogClockConfig() const override
+    {
+        return nullptr; /* 32X8 layout can only do digital.*/
+    }
+
+    /**
+     * Set the analog clock seconds display mode (none, ring, hand or both).
+     * 
+     * @return success of failure
+     */
+    virtual bool setAnalogClockConfig(const AnalogClockConfig& cfg) override
+    {
+        return true;  /* No analog clock in 32x8 layout, ignore request. */
+    }
+
+    /**
      * @brief Update current time values in view.
      * 
      * @param[in] now current time

--- a/lib/Views/src/layouts/DateTimeView64x64.cpp
+++ b/lib/Views/src/layouts/DateTimeView64x64.cpp
@@ -121,34 +121,54 @@ void DateTimeView64x64::update(YAGfx& gfx)
 
         gfx.fillScreen(ColorDef::BLACK);
 
-        m_textWidget.update(gfx);
-
         for (idx = 0; MAX_LAMPS > idx; ++idx)
         {
             m_lampWidgets[idx].update(gfx);
         }
 
-        /* Draw analog clock minute circle. */
-        drawAnalogClockBackground(gfx);
-
-        /* Draw analog clock hands. */
-        drawAnalogClockHand(gfx, m_now.tm_min, ANALOG_RADIUS - 6, ColorDef::GRAY);
-        drawAnalogClockHand(gfx, m_now.tm_hour * 5 + m_now.tm_min / 12 , ANALOG_RADIUS - 13, ColorDef::WHITE);
-
-        if (0U != (m_secondsDisplayMode & SECOND_DISP_HAND))
+        if ((ViewMode::DIGITAL_AND_ANALOG == m_mode) || (ViewMode::ANALOG_ONLY == m_mode))
         {
-            drawAnalogClockHand(gfx, m_now.tm_sec, ANALOG_RADIUS - 1, ColorDef::YELLOW);
+            uint32_t centerRingCol = m_analogClockCfg.m_colors[ANA_CLK_COL_HAND_MIN];
+
+            /* Draw analog clock minute circle. */
+            drawAnalogClockBackground(gfx);
+    
+            /* Draw analog clock hands. */
+            drawAnalogClockHand(
+                gfx, 
+                m_now.tm_min,
+                ANALOG_RADIUS - 6,
+                m_analogClockCfg.m_colors[ANA_CLK_COL_HAND_MIN]);
+
+            drawAnalogClockHand(gfx, 
+                m_now.tm_hour * 5 + m_now.tm_min / 12 ,
+                ANALOG_RADIUS - 13,
+                m_analogClockCfg.m_colors[ANA_CLK_COL_HAND_HOUR]);
+    
+            if (0U != (m_analogClockCfg.m_secondsMode & SECOND_DISP_HAND))
+            {
+                /* Use second hand color also for the middle ring if this hand is enabled. */
+                centerRingCol = m_analogClockCfg.m_colors[ANA_CLK_COL_HAND_SEC];
+                drawAnalogClockHand(
+                    gfx,
+                    m_now.tm_sec,
+                    ANALOG_RADIUS - 1,
+                    centerRingCol);
+            }
+    
+            /* Draw analog clock hand center */
+            gfx.drawRectangle(ANALOG_CENTER_X - 2, ANALOG_CENTER_Y - 2, 5, 5, centerRingCol);
+            gfx.drawPixel(ANALOG_CENTER_X, ANALOG_CENTER_Y, ColorDef::BLACK);
+            gfx.drawPixel(ANALOG_CENTER_X-2, ANALOG_CENTER_Y-2, ColorDef::BLACK);
+            gfx.drawPixel(ANALOG_CENTER_X-2, ANALOG_CENTER_Y+2, ColorDef::BLACK);
+            gfx.drawPixel(ANALOG_CENTER_X+2, ANALOG_CENTER_Y-2, ColorDef::BLACK);
+            gfx.drawPixel(ANALOG_CENTER_X+2, ANALOG_CENTER_Y+2, ColorDef::BLACK);
         }
 
-        /* Draw analog clock hand center */
-        gfx.drawRectangle(ANALOG_CENTER_X - 2, ANALOG_CENTER_Y - 2, 5, 5, ColorDef::YELLOW);
-        gfx.drawPixel(ANALOG_CENTER_X, ANALOG_CENTER_Y, ColorDef::BLACK);
-        gfx.drawPixel(ANALOG_CENTER_X-2, ANALOG_CENTER_Y-2, ColorDef::BLACK);
-        gfx.drawPixel(ANALOG_CENTER_X-2, ANALOG_CENTER_Y+2, ColorDef::BLACK);
-        gfx.drawPixel(ANALOG_CENTER_X+2, ANALOG_CENTER_Y-2, ColorDef::BLACK);
-        gfx.drawPixel(ANALOG_CENTER_X+2, ANALOG_CENTER_Y+2, ColorDef::BLACK);
-
-        m_textWidget.update(gfx);
+        if ((ViewMode::DIGITAL_AND_ANALOG == m_mode) || (ViewMode::DIGITAL_ONLY == m_mode))
+        {
+            m_textWidget.update(gfx);
+        }
 
         m_lastUpdateSecondVal = m_now.tm_sec;
     }
@@ -180,14 +200,14 @@ void DateTimeView64x64::drawAnalogClockBackground(YAGfx& gfx)
             int16_t xe(ANALOG_CENTER_X + (dx * (ANALOG_RADIUS - 4)) / SINUS_VAL_SCALE);
             int16_t ye(ANALOG_CENTER_Y + (dy * (ANALOG_RADIUS - 4)) / SINUS_VAL_SCALE);
 
-            gfx.drawLine(xs, ys, xe, ye, ColorDef::BLUE);
+            gfx.drawLine(xs, ys, xe, ye, m_analogClockCfg.m_colors[ANA_CLK_COL_RING_MIN5_MARK]);
         }
 
-        Color tickMarkCol(ColorDef::DARKGRAY);
-        if ((0U != (SECOND_DISP_RING & m_secondsDisplayMode)) && (angle <= secondAngle))
+        Color tickMarkCol = m_analogClockCfg.m_colors[ANA_CLK_COL_RING_MIN_DOT];
+        if ((0U != (SECOND_DISP_RING & m_analogClockCfg.m_secondsMode)) && (angle <= secondAngle))
         {
            /* Draw minute tick marks with passed seconds highlighting. */
-           tickMarkCol = ColorDef::YELLOW;
+           tickMarkCol = m_analogClockCfg.m_colors[ANA_CLK_COL_HAND_SEC];
         }
         gfx.drawPixel(xs, ys, tickMarkCol);
     }

--- a/lib/Views/src/layouts/DateTimeView64x64.h
+++ b/lib/Views/src/layouts/DateTimeView64x64.h
@@ -70,7 +70,18 @@ public:
      */
     DateTimeView64x64() :
         DateTimeViewGeneric(),
-        m_secondsDisplayMode(SECOND_DISP_RING),
+        m_mode(ViewMode::DIGITAL_AND_ANALOG),
+        m_analogClockCfg( 
+            { 
+                SECOND_DISP_RING,
+                {
+                    ColorDef::WHITE,
+                    ColorDef::GRAY,
+                    ColorDef::YELLOW,
+                    ColorDef::BLUE,
+                    ColorDef::YELLOW
+                } 
+            }),
         m_lastUpdateSecondVal(-1)
     {
         /* Disable fade effect in case the user required to show seconds,
@@ -101,20 +112,68 @@ public:
     void update(YAGfx& gfx) override;
 
 
+    /**
+     * Get the view mode (analog, digital or both).
+     * 
+     * @return ViewMode 
+     */
+    ViewMode getViewMode() const override
+    {
+        return m_mode;
+    }
 
+    /**
+     * Set the view mode (analog, digital or both).
+     * 
+     * @return success or failure
+     */
+    bool setViewMode(ViewMode mode) override
+    {
+        bool ret = false;
+
+        if (ViewMode::VIEW_MODE_MAX <= mode)
+        {
+            LOG_WARNING("Illegal DateTime view mode (%hhu)", mode);
+        }
+        else
+        {
+            m_mode = mode;
+            ret    = true;
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the analog clock configuration.
+     * 
+     * @return SecondsDisplayMode 
+     */
+    const AnalogClockConfig* getAnalogClockConfig() const override
+    {
+        return &m_analogClockCfg;
+    }
+
+    /**
+     * Set the analog clock configuration.
+     * 
+     * @return success of failure
+     */
+    bool setAnalogClockConfig(const AnalogClockConfig& cfg) override
+    {
+        if (SecondsDisplayMode::SECONDS_DISP_MAX <= cfg.m_secondsMode)
+        {
+            LOG_WARNING("Illegal Seconds Display mode (%hhu)", cfg.m_secondsMode);
+            return false;
+        }
+
+        m_analogClockCfg = cfg;
+        return true;
+    }
 protected:
 
-    /** Options for displaying seconds in analog clock
-     */
-    enum SecondsDisplayMode
-    {
-        SECOND_DISP_OFF = 0U,  /**< No second indicator display. */
-        SECOND_DISP_HAND = 1U, /**< Draw second clock hand. */
-        SECOND_DISP_RING = 2U, /**< Show passed seconds on minute tick ring. */
-        SECOND_DISP_BOTH = 3U, /**< Show hand and on ring. */
-    };
-
-    SecondsDisplayMode m_secondsDisplayMode; /**< How to visualize seconds in analog clock. */
+    ViewMode           m_mode;               /**< Used View mode analog, digital or both.  */
+    AnalogClockConfig  m_analogClockCfg;     /**< The clock drawing configuration options. */
 
 
     /**

--- a/src/Web/Pages.cpp
+++ b/src/Web/Pages.cpp
@@ -37,6 +37,7 @@
 #include "Version.h"
 #include "UpdateMgr.h"
 #include "DisplayMgr.h"
+#include "Display.h"
 #include "RestApi.h"
 #include "PluginList.h"
 #include "WiFiUtil.h"
@@ -159,7 +160,9 @@ static TmplKeyWordFunc  gTmplKeyWordToFunc[]            =
     "TARGET",               []() -> String { return Version::TARGET; },
     "WS_ENDPOINT",          []() -> String { return WebConfig::WEBSOCKET_PATH; },
     "WS_PORT",              []() -> String { return String(WebConfig::WEBSOCKET_PORT); },
-    "WS_PROTOCOL",          []() -> String { return WebConfig::WEBSOCKET_PROTOCOL; }
+    "WS_PROTOCOL",          []() -> String { return WebConfig::WEBSOCKET_PROTOCOL; },
+    "DISPLAY_HEIGHT",       []() -> String { return String(Display::getInstance().getHeight()); },
+    "DISPLAY_WIDTH",        []() -> String { return String(Display::getInstance().getWidth()); }
 };
 
 /******************************************************************************


### PR DESCRIPTION
HTML:
* Make config container responsive No margin below small devices
* Add radio button groups for analog mode
* Allow to customize seconds visualisation over web pages (radio buttons).

Webserver:
Added keyword DISPLAY_HEIGHT and DISPLAY_WIDTH.
They get replaced with the resolution of
the display. Used to enable/disable resolution
dependend elements.