### PR TITLE
Optimize GETDISP Websocket Command

### DIFF
--- a/data/display.html
+++ b/data/display.html
@@ -119,8 +119,6 @@
         <!-- Custom javascript -->
         <script>
             var ctx                 = null;     // Canvas context
-            var pixelWidth          = 10;       // Width of a single LED in pixels
-            var pixelHeight         = 10;       // Height of a single LED in pixels
             var isDisplayUpdateOn   = false;
             var timerId             = 0;        // Timer id
             var period              = 400;      // Display refresh period in ms
@@ -130,6 +128,14 @@
             var autoBrightnessCtrl  = false;    // Is automatic brightness control enabled or disabled?
             var brightness          = 0;        // Brightness [0; 255]
             var currentFadeEffect   = 0         // Fade effect [1;3]
+            
+            const PIXEL_WIDTH       = 10;               // Width of a single LED in pixels
+            const PIXEL_HEIGTH      = 10;               // Height of a single LED in pixels
+            const DISPLAY_WIDTH     = ~DISPLAY_WIDTH~;  // Width in pixels (Updated by webserver on send)
+            const DISPLAY_HEIGHT    = ~DISPLAY_HEIGHT~; // Height in pixels (Updated by webserver on send)
+
+            const CANVAS_WIDTH      = (DISPLAY_WIDTH) * PIXEL_WIDTH + (DISPLAY_WIDTH) + 1;
+            const CANVAS_HEIGHT     = (DISPLAY_HEIGHT) * PIXEL_HEIGTH + (DISPLAY_HEIGHT) + 1;
 
             /* Disable all UI elements. */
             function disableUI() {
@@ -159,46 +165,44 @@
                     ctx.lineWidth   = "1";
                     ctx.strokeStyle = color;
                     ctx.fillStyle   = color;
-                    ctx.fillRect(x * pixelWidth + x + 1, y * pixelHeight + y + 1, pixelWidth, pixelHeight);
+                    ctx.fillRect(x * PIXEL_WIDTH + x + 1, y * PIXEL_HEIGTH + y + 1, PIXEL_WIDTH, PIXEL_HEIGTH);
                 }
             }
 
             function getDisplayContent() {
                 wsClient.getDisplayContent().then(function(rsp) {
-                    var index   = 0;
-                    var color   = 0;
-                    var repeat  = 0;
-                    var pixel   = 0;
-
+                    let index   = 0;              // Index in input sequence.
+                    let pixelIndex = 0;           // Index as pixel offset from framebuffer start.
+                    
                     $("#slotId").text(rsp.slotId);
 
                     /* If necessary, resize the canvas. */
                     var $canvas = $("#canvas");
                     var ctx = $canvas[0].getContext('2d');
-                    var width = (~DISPLAY_WIDTH~) * pixelWidth + (~DISPLAY_WIDTH~) + 1;
-                    var height = (~DISPLAY_HEIGHT~) * pixelWidth + (~DISPLAY_HEIGHT~) + 1;
 
-                    if ((ctx.canvas.width != width) || (ctx.canvas.height != height)) {
-                        ctx.canvas.width = width;
-                        ctx.canvas.height = height;
-                    }
-                    
+                    if ((ctx.canvas.width != CANVAS_WIDTH) || (ctx.canvas.height != CANVAS_HEIGHT)) {
+                        ctx.canvas.width = CANVAS_WIDTH;
+                        ctx.canvas.height = CANVAS_HEIGHT;
+                    }                  
 
-                    /* Handle display data <repeat>:<R>:<G>:<B> */
+                    /* Handle display data */
                     while (index < rsp.data.length) {
-                        color   = rsp.data[index];
-                        repeat  = (color & 0xFF000000) >>> 24;
-                        red     = (color & 0x00FF0000) >>> 16;
-                        green   = (color & 0x0000FF00) >>> 8;
-                        blue    = (color & 0x000000FF) >>> 0;
-                        colFmt  = "rgb(" + red + ", " + green + ", " + blue + ")";
+                        let color   = rsp.data[index];
+                        let repeat  = (color & 0xFF000000) >>> 24;
+                        let red     = (color & 0x00FF0000) >>> 16;
+                        let green   = (color & 0x0000FF00) >>> 8;
+                        let blue    = (color & 0x000000FF) >>> 0;
+                        let colFmt  = "rgb(" + red + ", " + green + ", " + blue + ")";
 
                         do {
-                            plot(pixel % ~DISPLAY_WIDTH~ , Math.floor(pixel / ~DISPLAY_WIDTH~), colFmt);
+                            let x = pixelIndex % DISPLAY_WIDTH;
+                            let y = Math.floor(pixelIndex / DISPLAY_WIDTH);
+                            
+                            plot(x, y, colFmt);
+
                             --repeat;
-                            ++pixel;
+                            ++pixelIndex;
                         } while (repeat >= 0);
-                        
                         ++index;
                     }
                     

--- a/data/display.html
+++ b/data/display.html
@@ -50,6 +50,9 @@
                 <h1 class="mt-5">Display</h1>
                 <p>Slot: <span id="slotId">-</span></p>
                 <canvas id="canvas" width="353" height="89" style="border: 1px solid #000000; background-color: black;"></canvas>
+                <p>
+                    <button id="updateDisplayButton" class="btn btn-light" type="button" onclick="updateDisplay()" disabled>Enable auto. display update</button>
+                </p>
                 <p>Note, you can move the plugins with drag'n drop to other slots.</p>
                 <div id="divSlots">
                 </div>
@@ -62,7 +65,6 @@
                 <p>
                     <button class="btn btn-light" type="button" onclick="prevSlot()" disabled>Previous slot</button>
                     <button class="btn btn-light" type="button" onclick="nextSlot()" disabled>Next slot</button>
-                    <button id="updateDisplayButton" class="btn btn-light" type="button" onclick="updateDisplay()" disabled>Enable auto. display update</button>
                 </p>
                 <p>Currently active fade effect: <span id="lableFadeEffect"> Linear</span></p>
                 <p><button class="btn btn-light" type="button" onclick="nextEffect()" disabled>Next fade effect</button></p>
@@ -163,37 +165,42 @@
 
             function getDisplayContent() {
                 wsClient.getDisplayContent().then(function(rsp) {
-                    var x       = 0;
-                    var y       = 0;
                     var index   = 0;
                     var color   = 0;
+                    var repeat  = 0;
+                    var pixel   = 0;
 
                     $("#slotId").text(rsp.slotId);
 
                     /* If necessary, resize the canvas. */
                     var $canvas = $("#canvas");
                     var ctx = $canvas[0].getContext('2d');
-                    var width = rsp.width * pixelWidth + rsp.width + 1;
-                    var height = rsp.height * pixelWidth + rsp.height + 1;
+                    var width = (32 + 1) * pixelWidth + 1;
+                    var height = (8 + 1) * pixelWidth + 1;
 
                     if ((ctx.canvas.width != width) || (ctx.canvas.height != height)) {
                         ctx.canvas.width = width;
                         ctx.canvas.height = height;
                     }
+                    
 
                     /* Handle display data */
-                    for(y = 0; y < rsp.height; ++y) {
-                        for(x = 0; x < rsp.width; ++x) {
-                            if (rsp.data.length > index) {
-                                color   = rsp.data[index];
-                                red     = (color & 0xff0000) >> 16;
-                                green   = (color & 0x00ff00) >> 8;
-                                blue    = (color & 0x0000ff) >> 0;
-                                plot(x, y, "rgb(" + red + ", " + green + ", " + blue + ")");
-                                ++index;
-                            }
-                        }
+                    while (index < rsp.data.length) {
+                        color   = rsp.data[index];
+                        repeat  = (color & 0xFF000000) >> 24;
+                        red     = (color & 0x00FF0000) >> 16;
+                        green   = (color & 0x0000FF00) >> 8;
+                        blue    = (color & 0x000000FF) >> 0;
+                        colFmt  = "rgb(" + red + ", " + green + ", " + blue + ")";
+
+                        do {
+                            plot(pixel % 32 , Math.floor(pixel / 32), colFmt);
+                            --repeat;
+                            ++pixel;
+                        } while (repeat >= 0);
+                        ++index;
                     }
+                    
                 }).catch(function(err) {
                     if ("undefined" !== typeof err) {
                         console.error(err);

--- a/data/display.html
+++ b/data/display.html
@@ -175,8 +175,8 @@
                     /* If necessary, resize the canvas. */
                     var $canvas = $("#canvas");
                     var ctx = $canvas[0].getContext('2d');
-                    var width = (32 + 1) * pixelWidth + 1;
-                    var height = (8 + 1) * pixelWidth + 1;
+                    var width = (~DISPLAY_WIDTH~) * pixelWidth + (~DISPLAY_WIDTH~) + 1;
+                    var height = (~DISPLAY_HEIGHT~) * pixelWidth + (~DISPLAY_HEIGHT~) + 1;
 
                     if ((ctx.canvas.width != width) || (ctx.canvas.height != height)) {
                         ctx.canvas.width = width;
@@ -184,20 +184,21 @@
                     }
                     
 
-                    /* Handle display data */
+                    /* Handle display data <repeat>:<R>:<G>:<B> */
                     while (index < rsp.data.length) {
                         color   = rsp.data[index];
-                        repeat  = (color & 0xFF000000) >> 24;
-                        red     = (color & 0x00FF0000) >> 16;
-                        green   = (color & 0x0000FF00) >> 8;
-                        blue    = (color & 0x000000FF) >> 0;
+                        repeat  = (color & 0xFF000000) >>> 24;
+                        red     = (color & 0x00FF0000) >>> 16;
+                        green   = (color & 0x0000FF00) >>> 8;
+                        blue    = (color & 0x000000FF) >>> 0;
                         colFmt  = "rgb(" + red + ", " + green + ", " + blue + ")";
 
                         do {
-                            plot(pixel % 32 , Math.floor(pixel / 32), colFmt);
+                            plot(pixel % ~DISPLAY_WIDTH~ , Math.floor(pixel / ~DISPLAY_WIDTH~), colFmt);
                             --repeat;
                             ++pixel;
                         } while (repeat >= 0);
+                        
                         ++index;
                     }
                     

--- a/data/js/ws.js
+++ b/data/js/ws.js
@@ -171,8 +171,6 @@ pixelix.ws.Client.prototype._onMessage = function(msg) {
                 this._pendingCmd.resolve(rsp);
             } else if ("GETDISP" === this._pendingCmd.name) {
                 rsp.slotId = parseInt(data.shift());
-                rsp.width = parseInt(data.shift());
-                rsp.height = parseInt(data.shift());
                 rsp.data = [];
                 for(index = 0; index < data.length; ++index) {
                     rsp.data.push(parseInt(data[index], 16));

--- a/src/Web/WsCommand/WsCmd.cpp
+++ b/src/Web/WsCommand/WsCmd.cpp
@@ -55,13 +55,13 @@
  *****************************************************************************/
 
 /* Delimiter of websocket parameters */
-const char*    WsCmd::DELIMITER = ";";
+const char   WsCmd::DELIMITER[] = ";";
 
 /* Positive response code */
-const char*    WsCmd::ACK       = "ACK";
+const char    WsCmd::ACK[]       = "ACK";
 
 /* Negative response code. */
-const char*    WsCmd::NACK      = "NACK";
+const char    WsCmd::NACK[]      = "NACK";
 
 /******************************************************************************
  * Public Methods

--- a/src/Web/WsCommand/WsCmd.h
+++ b/src/Web/WsCommand/WsCmd.h
@@ -105,13 +105,13 @@ public:
 protected:
 
     /** Delimiter of websocket parameters */
-    static const char*    DELIMITER;
+    static const char    DELIMITER[];
 
     /** Positive response code */
-    static const char*    ACK;
+    static const char    ACK[];
 
     /** Negative response code. */
-    static const char*    NACK;
+    static const char    NACK[];
 
     /**
      * Prepare a positive response message.

--- a/src/Web/WsCommand/WsCmdGetDisp.cpp
+++ b/src/Web/WsCommand/WsCmdGetDisp.cpp
@@ -103,8 +103,8 @@ void WsCmdGetDisp::execute(AsyncWebSocket* server, uint32_t clientId)
             /* RGB data is send in a "compressed" format using a repeat counter in
              * the upper 8 bits. The send values are <rep>:<r>:<g>:<b>.
              * The repeat counter indicates how often the same color shall be used
-             * in subsequent pixels. Use a small state machine calculate the repeat
-             * counts.
+             * in subsequent pixels. Use a small state machine to calculate the
+             * repeat counter.
              *
              * Example:
              * A black only 32x8 framebuffer would be send as a single 0xFF000000 value.

--- a/src/Web/WsCommand/WsCmdGetDisp.h
+++ b/src/Web/WsCommand/WsCmdGetDisp.h
@@ -95,6 +95,20 @@ private:
 
     bool    m_isError;  /**< Any error happened during parameter reception? */
 
+    /**
+     * RGB data calculation states.
+     * 
+     * The RGB data is send in a "compressed" format using a repeat counter.
+     * The algorithm to calculate the format is implemented as a small state
+     * machine that creates sequences of repeated colors from the frame buffer.
+     */
+    enum GetDispState
+    {
+        STATE_GETDISP_COLLECT = 0, /**< Collect sequences of same color. */
+        STATE_GETDISP_SEND,        /**< Send current color sequence.     */
+        STATE_GETDISP_FINISH       /**< Terminate state machine.         */
+    };
+
     WsCmdGetDisp(const WsCmdGetDisp& cmd);
     WsCmdGetDisp& operator=(const WsCmdGetDisp& cmd);
 };


### PR DESCRIPTION
Add a simple "compression" to framebuffer uploads. The unused
upper 8 bits of an RGB value are now a repeat count. It tells how
often the same color shall be used on the pixels that follow.

Example:
To upload an empty black 32x8 frame buffer, only a
single 0xFF000000 data value will be send.