### PR TITLE
Feature/rest service without map

### DIFF
--- a/lib/AsyncHttpClient/src/AsyncHttpClient.cpp
+++ b/lib/AsyncHttpClient/src/AsyncHttpClient.cpp
@@ -106,8 +106,7 @@ AsyncHttpClient::AsyncHttpClient() :
     m_contentIndex(0U),
     m_chunkSize(0U),
     m_chunkIndex(0U),
-    m_chunkBodyPart(CHUNK_SIZE),
-    m_pendingCmdUserData(nullptr)
+    m_chunkBodyPart(CHUNK_SIZE)
 {
     (void)m_cmdQueue.create(CMD_QUEUE_SIZE);
     (void)m_evtQueue.create(EVT_QUEUE_SIZE);
@@ -443,37 +442,34 @@ void AsyncHttpClient::regOnError(const OnError& onError)
     m_onErrorCallback = onError;
 }
 
-bool AsyncHttpClient::GET(void* userData)
+bool AsyncHttpClient::GET()
 {
     Cmd cmd;
 
     memset(&cmd, 0, sizeof(cmd));
-    cmd.id       = CMD_ID_GET;
-    cmd.userData = userData;
+    cmd.id = CMD_ID_GET;
 
     return m_cmdQueue.sendToBack(cmd, portMAX_DELAY);
 }
 
-bool AsyncHttpClient::POST(const uint8_t* payload, size_t size, void* userData)
+bool AsyncHttpClient::POST(const uint8_t* payload, size_t size)
 {
     Cmd cmd;
 
     memset(&cmd, 0, sizeof(cmd));
     cmd.id          = CMD_ID_POST;
-    cmd.userData    = userData;
     cmd.u.data.data = payload;
     cmd.u.data.size = size;
 
     return m_cmdQueue.sendToBack(cmd, portMAX_DELAY);
 }
 
-bool AsyncHttpClient::POST(const String& payload, void* userData)
+bool AsyncHttpClient::POST(const String& payload)
 {
     Cmd cmd;
 
     memset(&cmd, 0, sizeof(cmd));
     cmd.id          = CMD_ID_POST;
-    cmd.userData    = userData;
     cmd.u.data.data = reinterpret_cast<const uint8_t*>(payload.c_str());
     cmd.u.data.size = payload.length();
 
@@ -610,8 +606,6 @@ void AsyncHttpClient::processCmdQueue()
             switch (cmd.id)
             {
             case CMD_ID_GET:
-                m_pendingCmdUserData = cmd.userData;
-
                 if (false == getRequest())
                 {
                     giveGlobalMutex();
@@ -619,8 +613,6 @@ void AsyncHttpClient::processCmdQueue()
                 break;
 
             case CMD_ID_POST:
-                m_pendingCmdUserData = cmd.userData;
-
                 if (false == postRequest(cmd.u.data.data, cmd.u.data.size))
                 {
                     giveGlobalMutex();
@@ -1487,7 +1479,7 @@ void AsyncHttpClient::notifyResponse()
 {
     if (nullptr != m_onRspCallback)
     {
-        m_onRspCallback(m_pendingCmdUserData, m_rsp);
+        m_onRspCallback(m_rsp);
     }
 }
 
@@ -1503,7 +1495,7 @@ void AsyncHttpClient::notifyError()
 {
     if (nullptr != m_onErrorCallback)
     {
-        m_onErrorCallback(m_pendingCmdUserData);
+        m_onErrorCallback();
     }
 }
 

--- a/lib/AsyncHttpClient/src/AsyncHttpClient.h
+++ b/lib/AsyncHttpClient/src/AsyncHttpClient.h
@@ -71,10 +71,8 @@ public:
 
     /**
      * Prototype of HTTP response callback for a complete received response.
-     *
-     * @param[in] userData Used to pass user-data which can be used in callbacks.
      */
-    typedef std::function<void(void* userData, const HttpResponse& rsp)> OnResponse;
+    typedef std::function<void(const HttpResponse& rsp)> OnResponse;
 
     /**
      * Prototype of HTTP response callback for a closed connection.
@@ -83,10 +81,8 @@ public:
 
     /**
      * Prototype of HTTP response callback in case a error happened.
-     *
-     * @param[in] userData Used to pass user-data which can be used in callbacks.
      */
-    typedef std::function<void(void* userData)> OnError;
+    typedef std::function<void()> OnError;
 
     /**
      * Constructs a http client.
@@ -188,31 +184,28 @@ public:
     /**
      * Send GET request to host.
      *
-     * @param[in] userData Used to pass user-data which can be used in callbacks.
      * @return If request is successful sent, it will return true otherwise false.
      */
-    bool GET(void* userData = nullptr);
+    bool GET();
 
     /**
      * Send POST request to host.
      *
      * @param[in] payload   Payload, which must be kept alive until response is available!
      * @param[in] size      Payload size in byte
-     * @param[in] userData  Used to pass user-data which can be used in callbacks.
      *
      * @return If request is successful sent, it will return true otherwise false.
      */
-    bool POST(const uint8_t* payload = nullptr, size_t size = 0U, void* userData = nullptr);
+    bool POST(const uint8_t* payload = nullptr, size_t size = 0U);
 
     /**
      * Send POST request to host.
      *
      * @param[in] payload   Payload, which must be kept alive until response is available!
-     * @param[in] userData  Used to pass user-data which can be used in callbacks.
      *
      * @return If request is successful sent, it will return true otherwise false.
      */
-    bool POST(const String& payload, void* userData = nullptr);
+    bool POST(const String& payload);
 
 private:
 
@@ -252,8 +245,7 @@ private:
      */
     struct Cmd
     {
-        CmdId id;       /**< The command id identifies the kind of request. */
-        void* userData; /**< Points to a user's data. */
+        CmdId id; /**< The command id identifies the kind of request. */
 
         /**
          * The union contains the event id specific parameters.
@@ -382,16 +374,15 @@ private:
     const uint8_t* m_payload;             /**< Request payload */
     size_t         m_payloadSize;         /**< Request payload size in byte */
 
-    ResponsePart   m_rspPart;            /**< Current parsing part of the response */
-    HttpResponse   m_rsp;                /**< Response */
-    String         m_rspLine;            /**< Single line, used for response parsing */
-    TransferCoding m_transferCoding;     /**< Transfer coding */
-    size_t         m_contentLength;      /**< Content length in byte */
-    size_t         m_contentIndex;       /**< Content index */
-    size_t         m_chunkSize;          /**< Chunk size in byte */
-    size_t         m_chunkIndex;         /**< Chunk body index */
-    ChunkBodyPart  m_chunkBodyPart;      /**< Current part of chunked response */
-    void*          m_pendingCmdUserData; /**< Used to identify plugin in RestService */
+    ResponsePart   m_rspPart;        /**< Current parsing part of the response */
+    HttpResponse   m_rsp;            /**< Response */
+    String         m_rspLine;        /**< Single line, used for response parsing */
+    TransferCoding m_transferCoding; /**< Transfer coding */
+    size_t         m_contentLength;  /**< Content length in byte */
+    size_t         m_contentIndex;   /**< Content index */
+    size_t         m_chunkSize;      /**< Chunk size in byte */
+    size_t         m_chunkIndex;     /**< Chunk body index */
+    ChunkBodyPart  m_chunkBodyPart;  /**< Current part of chunked response */
 
     AsyncHttpClient(const AsyncHttpClient& client);
     AsyncHttpClient& operator=(const AsyncHttpClient& client);

--- a/lib/GrabViaRestPlugin/src/GrabViaRestPlugin.h
+++ b/lib/GrabViaRestPlugin/src/GrabViaRestPlugin.h
@@ -100,7 +100,6 @@ public:
      */
     ~GrabViaRestPlugin()
     {
-        RestService::getInstance().deleteCallback(&m_restId);
         m_mutex.destroy();
     }
 

--- a/lib/RestService/src/RestService.cpp
+++ b/lib/RestService/src/RestService.cpp
@@ -339,8 +339,8 @@ void RestService::handleAsyncWebResponse(const HttpResponse& rsp)
                 isError = true;
             }
 
-            /* If a filter is found, it shall be applied.*/
-            else if (m_activePreProcessCallback)
+            /* If a callback is found, it shall be applied.*/
+            else if (nullptr != m_activePreProcessCallback)
             {
                 if (true == m_activePreProcessCallback(payload, payloadSize, *jsonDoc))
                 {

--- a/lib/RestService/src/RestService.cpp
+++ b/lib/RestService/src/RestService.cpp
@@ -61,11 +61,11 @@
 bool RestService::start()
 {
     bool                        isSuccessful = false;
-    AsyncHttpClient::OnResponse rspCallback  = [this](void* restId, const HttpResponse& rsp) {
-        handleAsyncWebResponse(restId, rsp);
+    AsyncHttpClient::OnResponse rspCallback  = [this](const HttpResponse& rsp) {
+        handleAsyncWebResponse(rsp);
     };
-    AsyncHttpClient::OnError errCallback = [this](void* restId) {
-        handleFailedWebRequest(restId);
+    AsyncHttpClient::OnError errCallback = [this]() {
+        handleFailedWebRequest();
     };
     AsyncHttpClient::OnClosed closedCallback = [this]() {
         m_isWaitingForResponse = false;
@@ -113,19 +113,22 @@ void RestService::process()
 
             if (nullptr != cmd)
             {
+                m_activeRestId             = cmd->restId;
+                m_activePreProcessCallback = cmd->preProcessCallback;
+
                 if (true == m_client.begin(String(cmd->url)))
                 {
                     switch (cmd->id)
                     {
                     case CMD_ID_GET:
-                        if (false == m_client.GET(cmd->restId))
+                        if (false == m_client.GET())
                         {
                             isError = true;
                         }
                         break;
 
                     case CMD_ID_POST:
-                        if (false == m_client.POST(cmd->u.data.data, cmd->u.data.size, cmd->restId))
+                        if (false == m_client.POST(cmd->u.data.data, cmd->u.data.size))
                         {
                             isError = true;
                         }
@@ -141,6 +144,10 @@ void RestService::process()
                     isError = true;
                 }
             }
+            else
+            {
+                isError = true;
+            }
 
             if (true == isError)
             {
@@ -155,7 +162,9 @@ void RestService::process()
                     LOG_ERROR("Msg could not be sent to Msg-Queue");
                 }
 
-                m_isWaitingForResponse = false;
+                m_activeRestId             = nullptr;
+                m_activePreProcessCallback = nullptr;
+                m_isWaitingForResponse     = false;
             }
         }
 
@@ -167,34 +176,7 @@ void RestService::process()
     }
 }
 
-void RestService::setCallback(void* restId, PreProcessCallback preProcessCallback)
-{
-    if (nullptr == restId)
-    {
-        LOG_ERROR("Callback cannot be set with nullptr as restId!");
-    }
-    else
-    {
-        if (m_Callbacks.find(restId) == m_Callbacks.end())
-        {
-            m_Callbacks[restId] = preProcessCallback;
-        }
-    }
-}
-
-void RestService::deleteCallback(void* restId)
-{
-    if (nullptr == restId)
-    {
-        LOG_ERROR("Cannot delete callback for restId: nullptr!");
-    }
-    else
-    {
-        m_Callbacks.erase(restId);
-    }
-}
-
-bool RestService::get(void* restId, const String& url)
+bool RestService::get(void* restId, const String& url, PreProcessCallback preProcessCallback)
 {
     bool isSuccessful = true;
 
@@ -214,10 +196,11 @@ bool RestService::get(void* restId, const String& url)
         }
         else
         {
-            cmd->id      = CMD_ID_GET;
-            cmd->restId  = restId;
-            cmd->url     = url;
-            isSuccessful = m_cmdQueue.sendToBack(cmd, portMAX_DELAY);
+            cmd->id                 = CMD_ID_GET;
+            cmd->restId             = restId;
+            cmd->preProcessCallback = preProcessCallback;
+            cmd->url                = url;
+            isSuccessful            = m_cmdQueue.sendToBack(cmd, portMAX_DELAY);
         }
 
         if (false == isSuccessful)
@@ -230,7 +213,7 @@ bool RestService::get(void* restId, const String& url)
     return isSuccessful;
 }
 
-bool RestService::post(void* restId, const String& url, const uint8_t* payload, size_t size)
+bool RestService::post(void* restId, const String& url, PreProcessCallback preProcessCallback, const uint8_t* payload, size_t size)
 {
     bool isSuccessful = true;
 
@@ -250,12 +233,13 @@ bool RestService::post(void* restId, const String& url, const uint8_t* payload, 
         }
         else
         {
-            cmd->id          = CMD_ID_POST;
-            cmd->restId      = restId;
-            cmd->url         = url;
-            cmd->u.data.data = payload;
-            cmd->u.data.size = size;
-            isSuccessful     = m_cmdQueue.sendToBack(cmd, portMAX_DELAY);
+            cmd->id                 = CMD_ID_POST;
+            cmd->restId             = restId;
+            cmd->preProcessCallback = preProcessCallback;
+            cmd->url                = url;
+            cmd->u.data.data        = payload;
+            cmd->u.data.size        = size;
+            isSuccessful            = m_cmdQueue.sendToBack(cmd, portMAX_DELAY);
         }
 
         if (false == isSuccessful)
@@ -268,7 +252,7 @@ bool RestService::post(void* restId, const String& url, const uint8_t* payload, 
     return isSuccessful;
 }
 
-bool RestService::post(void* restId, const String& url, const String& payload)
+bool RestService::post(void* restId, const String& url, const String& payload, PreProcessCallback preProcessCallback)
 {
     bool isSuccessful = true;
 
@@ -288,12 +272,13 @@ bool RestService::post(void* restId, const String& url, const String& payload)
         }
         else
         {
-            cmd->id          = CMD_ID_POST;
-            cmd->restId      = restId;
-            cmd->url         = url;
-            cmd->u.data.data = reinterpret_cast<const uint8_t*>(payload.c_str());
-            cmd->u.data.size = payload.length();
-            isSuccessful     = m_cmdQueue.sendToBack(cmd, portMAX_DELAY);
+            cmd->id                 = CMD_ID_POST;
+            cmd->restId             = restId;
+            cmd->url                = url;
+            cmd->preProcessCallback = preProcessCallback;
+            cmd->u.data.data        = reinterpret_cast<const uint8_t*>(payload.c_str());
+            cmd->u.data.size        = payload.length();
+            isSuccessful            = m_cmdQueue.sendToBack(cmd, portMAX_DELAY);
         }
 
         if (false == isSuccessful)
@@ -329,14 +314,14 @@ bool RestService::getResponse(void* restId, bool& isValidRsp, DynamicJsonDocumen
     return isSuccessful;
 }
 
-void RestService::handleAsyncWebResponse(void* restId, const HttpResponse& rsp)
+void RestService::handleAsyncWebResponse(const HttpResponse& rsp)
 {
     const size_t         JSON_DOC_SIZE = 4096U;
     DynamicJsonDocument* jsonDoc       = new (std::nothrow) DynamicJsonDocument(JSON_DOC_SIZE);
     bool                 isError       = false;
     Msg                  msg;
 
-    msg.restId = restId;
+    msg.restId = m_activeRestId;
 
     if (HttpStatus::STATUS_CODE_OK == rsp.getStatusCode())
     {
@@ -355,9 +340,9 @@ void RestService::handleAsyncWebResponse(void* restId, const HttpResponse& rsp)
             }
 
             /* If a filter is found, it shall be applied.*/
-            else if (m_Callbacks.find(restId) != m_Callbacks.end())
+            else if (m_activePreProcessCallback)
             {
-                if (true == m_Callbacks[restId](payload, payloadSize, *jsonDoc))
+                if (true == m_activePreProcessCallback(payload, payloadSize, *jsonDoc))
                 {
                     msg.isMsg = true;
                     msg.rsp   = jsonDoc;
@@ -419,13 +404,16 @@ void RestService::handleAsyncWebResponse(void* restId, const HttpResponse& rsp)
             LOG_ERROR("Msg could not be sent to Msg-Queue");
         }
     }
+
+    m_activeRestId             = nullptr;
+    m_activePreProcessCallback = nullptr;
 }
 
-void RestService::handleFailedWebRequest(void* restId)
+void RestService::handleFailedWebRequest()
 {
     Msg msg;
 
-    msg.restId = restId;
+    msg.restId = m_activeRestId;
     msg.isMsg  = false;
     msg.rsp    = nullptr;
 
@@ -433,6 +421,9 @@ void RestService::handleFailedWebRequest(void* restId)
     {
         LOG_ERROR("Msg could not be sent to Msg-Queue");
     }
+
+    m_activeRestId             = nullptr;
+    m_activePreProcessCallback = nullptr;
 }
 
 /******************************************************************************

--- a/lib/RestService/src/RestService.h
+++ b/lib/RestService/src/RestService.h
@@ -108,7 +108,7 @@ public:
      *
      * @param[in] restId              Unique Id to identify plugin
      * @param[in] url                 URL
-     * @param[in] preProcessCallback  PreProcessCallback which shall be called when response arrives.
+     * @param[in] preProcessCallback  PreProcessCallback which will be called by the RestService to filter the received date.
      *
      * @return If request is successful sent, it will return true otherwise false.
      */
@@ -119,7 +119,7 @@ public:
      *
      * @param[in] restId              Unique Id to identify plugin
      * @param[in] url                 URL
-     * @param[in] preProcessCallback  PreProcessCallback which shall be called when response arrives.
+     * @param[in] preProcessCallback  PreProcessCallback which will be called by the RestService to filter the received date.
      * @param[in] payload             Payload, which must be kept alive until response is available!
      * @param[in] size                Payload size in byte
      *
@@ -132,7 +132,7 @@ public:
      * @param[in] restId              Unique Id to identify plugin
      * @param[in] url                 URL
      * @param[in] payload             Payload, which must be kept alive until response is available!
-     * @param[in] preProcessCallback  PreProcessCallback which shall be called when response arrives.
+     * @param[in] preProcessCallback  PreProcessCallback which will be called by the RestService to filter the received date.
      *
      * @return If request is successful sent, it will return true otherwise false.
      */
@@ -234,8 +234,8 @@ private:
     RestService() :
         IService(),
         m_client(),
-        m_taskProxy(),
         m_cmdQueue(),
+        m_taskProxy(),
         m_isWaitingForResponse(false),
         removedPluginIds(),
         m_isRunning(false),

--- a/src/SystemState/ConnectedState.cpp
+++ b/src/SystemState/ConnectedState.cpp
@@ -185,8 +185,7 @@ void ConnectedState::exit(StateMachine& sm)
 
 void ConnectedState::initHttpClient()
 {
-    m_client.regOnResponse([](void* userData, const HttpResponse& rsp) {
-        UTIL_NOT_USED(userData);
+    m_client.regOnResponse([](const HttpResponse& rsp) {
         uint16_t statusCode = rsp.getStatusCode();
 
         if (HttpStatus::STATUS_CODE_OK == statusCode)
@@ -195,9 +194,7 @@ void ConnectedState::initHttpClient()
         }
     });
 
-    m_client.regOnError([](void* userData) {
-        UTIL_NOT_USED(userData);
-
+    m_client.regOnError([]() {
         LOG_WARNING("Connection error happened.");
     });
 }


### PR DESCRIPTION
As of this PR it is not possible yet to "unregister" or "delete" the corresponding callback of a plugin when the plugin stops after starting a request. This will follow in the PR where the Queues will be changed to vectors.