### PR TITLE
Feature/rest service async http client changes

### DIFF
--- a/lib/AsyncHttpClient/src/AsyncHttpClient.cpp
+++ b/lib/AsyncHttpClient/src/AsyncHttpClient.cpp
@@ -704,8 +704,6 @@ void AsyncHttpClient::onConnect()
 
 void AsyncHttpClient::onDisconnect()
 {
-    bool wasConnectionEstablished = false;
-
     LOG_INFO("Disconnected from %s:%u%s.", m_hostname.c_str(), m_port, m_uri.c_str());
     LOG_DEBUG("Available heap: %u", ESP.getFreeHeap());
 
@@ -713,13 +711,7 @@ void AsyncHttpClient::onDisconnect()
     {
         MutexGuard<Mutex> guard(m_mutex);
 
-        wasConnectionEstablished = m_isConnected;
         m_isConnected            = false;
-    }
-
-    if (false == wasConnectionEstablished)
-    {
-        onError(ERR_CONN);
     }
 
     clear();

--- a/lib/AsyncHttpClient/src/AsyncHttpClient.h
+++ b/lib/AsyncHttpClient/src/AsyncHttpClient.h
@@ -355,6 +355,7 @@ private:
     /* Protected data */
     bool m_isConnected; /**< Is a connection established? */
     bool m_isReqOpen;   /**< Is a request open? */
+    bool m_isError;     /**< Has an error happened? */
 
     /* Non-protected data */
     OnResponse     m_onRspCallback;       /**< Callback which to call for a complete response. */

--- a/lib/AsyncHttpClient/src/AsyncHttpClient.h
+++ b/lib/AsyncHttpClient/src/AsyncHttpClient.h
@@ -355,7 +355,6 @@ private:
     /* Protected data */
     bool m_isConnected; /**< Is a connection established? */
     bool m_isReqOpen;   /**< Is a request open? */
-    bool m_isError;     /**< Has an error happened? */
 
     /* Non-protected data */
     OnResponse     m_onRspCallback;       /**< Callback which to call for a complete response. */
@@ -384,6 +383,7 @@ private:
     size_t         m_chunkSize;      /**< Chunk size in byte */
     size_t         m_chunkIndex;     /**< Chunk body index */
     ChunkBodyPart  m_chunkBodyPart;  /**< Current part of chunked response */
+    bool           m_isError;        /**< Has an error happened? */
 
     AsyncHttpClient(const AsyncHttpClient& client);
     AsyncHttpClient& operator=(const AsyncHttpClient& client);

--- a/lib/RestService/src/RestService.cpp
+++ b/lib/RestService/src/RestService.cpp
@@ -60,27 +60,20 @@
 
 bool RestService::start()
 {
-    MutexGuard<MutexRecursive>  guard(m_mutex);
+    MutexGuard<Mutex>           guard(m_mutex);
 
     AsyncHttpClient::OnResponse rspCallback = [this](const HttpResponse& rsp) {
         handleAsyncWebResponse(rsp);
     };
+    AsyncHttpClient::OnError errCallback = [this]() {
+        handleFailedWebRequest();
+    };
     AsyncHttpClient::OnClosed closedCallback = [this]() {
-        MutexGuard<MutexRecursive> guard(m_mutex);
-
-        if (false == m_wasOnResponseCalled)
-        {
-            handleFailedWebRequest();
-        }
-        else
-        {
-            m_wasOnResponseCalled = false;
-        }
-
         m_isWaitingForResponse = false;
     };
 
     m_client.regOnResponse(rspCallback);
+    m_client.regOnError(errCallback);
     m_client.regOnClosed(closedCallback);
     m_isRunning = true;
 
@@ -89,10 +82,11 @@ bool RestService::start()
 
 void RestService::stop()
 {
-    MutexGuard<MutexRecursive> guard(m_mutex);
+    MutexGuard<Mutex> guard(m_mutex);
 
     m_isRunning = false;
     m_client.regOnResponse(nullptr);
+    m_client.regOnError(nullptr);
     m_client.regOnClosed(nullptr);
     m_requestQueue.clear();
     m_client.end();
@@ -103,7 +97,7 @@ void RestService::stop()
 
 void RestService::process()
 {
-    MutexGuard<MutexRecursive> guard(m_mutex);
+    MutexGuard<Mutex> guard(m_mutex);
 
     if (false == m_isWaitingForResponse)
     {
@@ -165,9 +159,9 @@ void RestService::process()
 
 uint32_t RestService::get(const String& url, PreProcessCallback preProcessCallback)
 {
-    MutexGuard<MutexRecursive> guard(m_mutex);
-    bool                       isSuccessful = true;
-    uint32_t                   restId;
+    MutexGuard<Mutex> guard(m_mutex);
+    bool              isSuccessful = true;
+    uint32_t          restId;
 
     if (true == m_isRunning)
     {
@@ -191,9 +185,9 @@ uint32_t RestService::get(const String& url, PreProcessCallback preProcessCallba
 
 uint32_t RestService::post(const String& url, PreProcessCallback preProcessCallback, const uint8_t* payload, size_t size)
 {
-    MutexGuard<MutexRecursive> guard(m_mutex);
-    bool                       isSuccessful = true;
-    uint32_t                   restId;
+    MutexGuard<Mutex> guard(m_mutex);
+    bool              isSuccessful = true;
+    uint32_t          restId;
 
     if (true == m_isRunning)
     {
@@ -219,9 +213,9 @@ uint32_t RestService::post(const String& url, PreProcessCallback preProcessCallb
 
 uint32_t RestService::post(const String& url, const String& payload, PreProcessCallback preProcessCallback)
 {
-    MutexGuard<MutexRecursive> guard(m_mutex);
-    bool                       isSuccessful = true;
-    uint32_t                   restId;
+    MutexGuard<Mutex> guard(m_mutex);
+    bool              isSuccessful = true;
+    uint32_t          restId;
 
     if (true == m_isRunning)
     {
@@ -247,8 +241,8 @@ uint32_t RestService::post(const String& url, const String& payload, PreProcessC
 
 bool RestService::getResponse(uint32_t restId, bool& isValidRsp, DynamicJsonDocument& payload)
 {
-    MutexGuard<MutexRecursive> guard(m_mutex);
-    bool                       isSuccessful = false;
+    MutexGuard<Mutex> guard(m_mutex);
+    bool              isSuccessful = false;
 
     if (true == m_isRunning)
     {
@@ -281,10 +275,10 @@ bool RestService::getResponse(uint32_t restId, bool& isValidRsp, DynamicJsonDocu
 
 void RestService::abortRequest(uint32_t restId)
 {
-    MutexGuard<MutexRecursive> guard(m_mutex);
-    bool                       isRequestFound = false;
-    RequestQueue::iterator     reqIterator    = m_requestQueue.begin();
-    ResponseQueue::iterator    rspIterator    = m_responseQueue.begin();
+    MutexGuard<Mutex>       guard(m_mutex);
+    bool                    isRequestFound = false;
+    RequestQueue::iterator  reqIterator    = m_requestQueue.begin();
+    ResponseQueue::iterator rspIterator    = m_responseQueue.begin();
 
     while ((false == isRequestFound) && (reqIterator != m_requestQueue.end()))
     {
@@ -322,13 +316,21 @@ void RestService::abortRequest(uint32_t restId)
     }
 }
 
+/******************************************************************************
+ * Protected Methods
+ *****************************************************************************/
+
+/******************************************************************************
+ * Private Methods
+ *****************************************************************************/
+
 void RestService::handleAsyncWebResponse(const HttpResponse& httpRsp)
 {
-    MutexGuard<MutexRecursive> guard(m_mutex);
-    Response                   rsp;
-    bool                       isError = false;
+    MutexGuard<Mutex> guard(m_mutex);
+    Response          rsp;
+    bool              isError = false;
 
-    rsp.restId                         = m_activeRestId;
+    rsp.restId                = m_activeRestId;
 
     if (HttpStatus::STATUS_CODE_OK == httpRsp.getStatusCode())
     {
@@ -389,13 +391,12 @@ void RestService::handleAsyncWebResponse(const HttpResponse& httpRsp)
 
     m_activeRestId             = INVALID_REST_ID;
     m_activePreProcessCallback = nullptr;
-    m_wasOnResponseCalled      = true;
 }
 
 void RestService::handleFailedWebRequest()
 {
-    MutexGuard<MutexRecursive> guard(m_mutex);
-    Response                   rsp(0U);
+    MutexGuard<Mutex> guard(m_mutex);
+    Response          rsp(0U);
 
     rsp.restId = m_activeRestId;
     rsp.isRsp  = false;
@@ -424,14 +425,6 @@ uint32_t RestService::getRestId()
 
     return restId;
 }
-
-/******************************************************************************
- * Protected Methods
- *****************************************************************************/
-
-/******************************************************************************
- * Private Methods
- *****************************************************************************/
 
 /******************************************************************************
  * External Functions

--- a/lib/RestService/src/RestService.h
+++ b/lib/RestService/src/RestService.h
@@ -302,8 +302,7 @@ private:
     bool                          m_isWaitingForResponse;     /**< Is RestService still waiiting for a response to a request? */
     uint32_t                      m_activeRestId;             /**< Saves the  restId of a request until the callback triggered by the corresponding response is finished. */
     PreProcessCallback            m_activePreProcessCallback; /**< Saves the callback sent by a request until it is called when the response arrives. */
-    mutable MutexRecursive        m_mutex;                    /**< Mutex to protect against concurrent access. */
-    bool                          m_wasOnResponseCalled;      /**< Signals if the onResponse callback was called. */
+    Mutex                         m_mutex;                    /**< Mutex to protect against concurrent access. */
 
     /**
      * Constructs the service instance.
@@ -318,8 +317,7 @@ private:
         m_isWaitingForResponse(false),
         m_activeRestId(INVALID_REST_ID),
         m_activePreProcessCallback(),
-        m_mutex(),
-        m_wasOnResponseCalled(false)
+        m_mutex()
     {
         (void)m_mutex.create();
     }

--- a/lib/RestService/src/RestService.h
+++ b/lib/RestService/src/RestService.h
@@ -302,7 +302,8 @@ private:
     bool                          m_isWaitingForResponse;     /**< Is RestService still waiiting for a response to a request? */
     uint32_t                      m_activeRestId;             /**< Saves the  restId of a request until the callback triggered by the corresponding response is finished. */
     PreProcessCallback            m_activePreProcessCallback; /**< Saves the callback sent by a request until it is called when the response arrives. */
-    Mutex                         m_mutex;                    /**< Mutex to protect against concurrent access. */
+    mutable MutexRecursive        m_mutex;                    /**< Mutex to protect against concurrent access. */
+    bool                          m_wasOnResponseCalled;      /**< Signals if the onResponse callback was called. */
 
     /**
      * Constructs the service instance.
@@ -317,7 +318,8 @@ private:
         m_isWaitingForResponse(false),
         m_activeRestId(INVALID_REST_ID),
         m_activePreProcessCallback(),
-        m_mutex()
+        m_mutex(),
+        m_wasOnResponseCalled(false)
     {
         (void)m_mutex.create();
     }


### PR DESCRIPTION
Since AsyncHttpClient doesn't always call onError if an error happens onError callback of the RestService is now called if onClosed is called without a previous call of onResponse.

Our last solution did fix that problem but it also sometimes lead to more than one call of onError and one case where I believe that onError was still not called.  